### PR TITLE
feat: add editors & tokens tables + API access control in headers

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,7 +69,9 @@ model Declaration {
   factPersons                             Json?     @map("fact_persons")
   factGoods                               Json?     @map("fact_goods")
   reasons                                 Json?
-  reasonNotApparent                       Boolean   @map("reason_not_apparent") @default(false)
+  reasonNotApparent                       Boolean   @default(false) @map("reason_not_apparent")
+  editorId                                String?   @map("editor_id") @db.Uuid
+  editor                                  Editor?   @relation("declarationsToeditors", fields: [editorId], references: [id])
 
   @@map("declarations")
 }
@@ -126,4 +128,25 @@ model reports_history {
   sent_to String?   @db.VarChar(255)
 
   @@ignore
+}
+
+model Editor {
+  id           String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  createdAt    DateTime?     @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt    DateTime?     @map("updated_at") @db.Timestamptz(6)
+  name         String?       @db.VarChar(255)
+  declarations Declaration[] @relation("declarationsToeditors")
+  tokens       Token[]       @relation("editorsTotokens")
+
+  @@map("editors")
+}
+
+model Token {
+  id        String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  createdAt DateTime? @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime? @map("updated_at") @db.Timestamptz(6)
+  editorId  String?   @map("editor_id") @db.Uuid
+  editor    Editor?   @relation("editorsTotokens", fields: [editorId], references: [id])
+
+  @@map("tokens")
 }

--- a/src/__tests__/http/create-declaration.http
+++ b/src/__tests__/http/create-declaration.http
@@ -1,6 +1,7 @@
 # Création d'une déclaration de type ets
 # "id": "c1344a7e-64ea-4f9a-965d-bfd150110031",
 POST http://localhost:3030/api/declarations
+Authorization: Bearer 8045dead-a8a8-4532-b9a9-3b6faf81498f
 Content-Type: application/json
 
 {
@@ -112,6 +113,7 @@ Content-Type: application/json
 
 POST http://localhost:3030/api/declarations
 Content-Type: application/json
+Authorization: Bearer 5e679014-eec3-4956-96f8-f084c616c54e
 
 {
   "declarationType": "ets",
@@ -642,6 +644,7 @@ Content-Type: application/json
 
 ### From formulaire ets
 POST http://localhost:3030/api/declarations
+Authorization: Bearer 8045dead-a8a8-4532-b9a9-3b6faf81498f
 Content-Type: application/json
 
 {

--- a/src/knex/migrations/20210802102010_editors_table.js
+++ b/src/knex/migrations/20210802102010_editors_table.js
@@ -1,0 +1,35 @@
+const alterId = (table) =>
+  `alter table ${table} alter column id set default gen_random_uuid()`
+
+exports.up = async function (knex) {
+  await knex.schema.createTable("editors", (table) => {
+    table.uuid("id").primary()
+    table.timestamp("created_at", { useTz: true }).defaultTo(knex.fn.now())
+    table.timestamp("updated_at", { useTz: true })
+    table.string("name")
+  })
+
+  await knex.raw(alterId("editors"))
+
+  await knex.schema.createTable("tokens", (table) => {
+    table.uuid("id").primary()
+    table.timestamp("created_at", { useTz: true }).defaultTo(knex.fn.now())
+    table.timestamp("updated_at", { useTz: true })
+    table.uuid("editor_id").references("editors.id")
+  })
+
+  await knex.raw(alterId("tokens"))
+
+  await knex.schema.alterTable("declarations", (table) => {
+    table.uuid("editor_id").references("editors.id").nullable()
+  })
+}
+
+exports.down = async function (knex) {
+  await knex.schema.alterTable("declarations", (table) => {
+    table.dropColumn("editor_id")
+  })
+
+  await knex.schema.dropTable("tokens")
+  await knex.schema.dropTable("editors")
+}

--- a/src/knex/seeds/development/00_delete_all.js
+++ b/src/knex/seeds/development/00_delete_all.js
@@ -4,4 +4,7 @@ exports.seed = function (knex) {
     .del()
     .then(() => knex("declarations").del())
     .then(() => knex("reports_history").del())
+    .then(() => knex("ets").del())
+    .then(() => knex("tokens").del())
+    .then(() => knex("editors").del())
 }

--- a/src/knex/seeds/development/04_editors.js
+++ b/src/knex/seeds/development/04_editors.js
@@ -1,0 +1,16 @@
+exports.seed = function (knex) {
+  return knex("editors")
+    .del()
+    .then(function () {
+      return knex("editors").insert([
+        {
+          id: "e20d2341-aecf-4c42-aabb-b0a302060070",
+          name: "ONVS",
+        },
+        {
+          id: "4ccd78c2-4958-4d81-a17e-88a3c7675131",
+          name: "BlueKango",
+        },
+      ])
+    })
+}

--- a/src/knex/seeds/development/05_tokens.js
+++ b/src/knex/seeds/development/05_tokens.js
@@ -1,0 +1,16 @@
+exports.seed = function (knex) {
+  return knex("tokens")
+    .del()
+    .then(function () {
+      return knex("tokens").insert([
+        {
+          id: "5e679014-eec3-4956-96f8-f084c616c54e",
+          editor_id: "e20d2341-aecf-4c42-aabb-b0a302060070",
+        },
+        {
+          id: "8045dead-a8a8-4532-b9a9-3b6faf81498f",
+          editor_id: "4ccd78c2-4958-4d81-a17e-88a3c7675131",
+        },
+      ])
+    })
+}

--- a/src/models/declarations/index.ts
+++ b/src/models/declarations/index.ts
@@ -319,19 +319,25 @@ const liberalAddonSchema = z.object({
 // Specificity for ETS.
 const etsAddonSchema = z.object({
   declarationType: z.literal(DeclarationType.Ets),
-  finesset: z.string().refine(async (finesset) => {
-    try {
-      const ets = await prisma.ets.findUnique({
-        where: {
-          finesset,
-        },
-      })
-      return ets !== null
-    } catch (error) {
-      console.error("Erreur lors du test du finesset")
-      return false
-    }
-  }),
+  finesset: z
+    .string()
+    .regex(/^[0-9]{9}$/, "Le n° FINESS doit être composé de 9 chiffres."),
+  editorId: z.string().refine(
+    async (id) => {
+      try {
+        const editor = await prisma.editor.findUnique({
+          where: {
+            id,
+          },
+        })
+        return editor !== null
+      } catch (error) {
+        console.error("Le champ editorId ne correspond pas à un éditeur connu.")
+        return false
+      }
+    },
+    { message: "Le champ editorId ne correspond pas à un éditeur connu." },
+  ),
 
   locationMain_deprecated: z.string(), // TODO: remove when time has come
   locationSecondary_deprecated: z.string(), // TODO: remove when time has come

--- a/src/models/editor.ts
+++ b/src/models/editor.ts
@@ -1,0 +1,3 @@
+import { Editor } from "@prisma/client"
+
+export type EditorModel = Editor

--- a/src/pages/api/nomenclatures.ts
+++ b/src/pages/api/nomenclatures.ts
@@ -1,0 +1,126 @@
+import Cors from "micro-cors"
+import { handleErrors, handleNotAllowedMethods } from "@/utils/api"
+import * as options from "@/utils/options"
+
+function flatten(obj) {
+  return Object.keys(obj).reduce(
+    (acc, key) => ({
+      ...acc,
+      ...{
+        [obj[key].label]: obj[key].options,
+      },
+    }),
+    {},
+  )
+}
+
+const handler = async (req, res) => {
+  res.setHeader("Content-Type", "application/json")
+  res.setHeader("Cache-Control", "public, max-age=60, must-revalidate")
+
+  try {
+    switch (req.method) {
+      case "GET": {
+        return res.status(200).json({
+          factPersonsGroups: {
+            description:
+              "Groupe des faits de violence concernant les personnes",
+            relatedField: "factPersons",
+            values: flatten(options.factPersonsGroups),
+          },
+          factGoodsGroups: {
+            description: "Groupe des faits de violence concernant les biens",
+            relatedField: "factGoods",
+            values: flatten(options.factGoodsGroups),
+          },
+          reasons: {
+            description: "Motifs des violences",
+            relatedField: "reasons",
+            values: flatten(options.reasons),
+          },
+          hours: {
+            description: "Champ horaire",
+            relatedField: "hour",
+            values: options.hours,
+          },
+          mainLocation: {
+            description: "Dans quel service ? (lieu principal)",
+            relatedField: "",
+            values: options.etsMainLocations,
+          },
+          secondaryLocations: {
+            description: "Dans quel lieu précisément ? (lieu secondaire)",
+            relatedField: "",
+            values: options.etsSecondaryLocations,
+          },
+          healthJobs: {
+            description:
+              "Liste des professions de santé, éventuellement demandé si le type d'une victim ou d'un auteur correspond à une profession de santé",
+            relatedField: "",
+            values: options.healthJobs,
+          },
+          healthTypes: {
+            description:
+              "Type qui nécessite une précision sur la profession de santé",
+            relatedField: "N/A",
+            values: options.healthTypes,
+          },
+          victimTypes: {
+            description:
+              "Liste des types (profession ou autres) pour les victimes",
+            relatedField: "victim.type",
+            values: options.victimTypes,
+          },
+          authorTypes: {
+            description:
+              "Liste des types (profession ou autres) pour les auteurs",
+            relatedField: "author.type",
+            values: options.authorTypes,
+          },
+          ages: {
+            description: "Champs âges des victimes ou auteurs",
+            relatedField: "victim.age / author.age",
+            values: options.ages,
+          },
+          genders: {
+            description: "Genre des victimes ou auteurs",
+            relatedField: "victim.gender / author.gender",
+            values: options.genders,
+          },
+          pursuits: {
+            description: "Poursuites",
+            relatedField: "pursuit",
+            values: options.pursuits,
+          },
+          pursuitComplaintsByValues: {
+            description: "Options quand la poursuite est Plainte",
+            relatedField: "pursuit.pursuitBy",
+            values: options.pursuitComplaintsByValues,
+          },
+          thirdParties: {
+            description: "Liste pour les intervention de tiers",
+            relatedField: "thirdParty",
+            values: options.thirdParties,
+          },
+          discernmentTroubles: {
+            description: "Liste des troubles du discernement",
+            relatedField: "author.discernmentTroubles",
+            values: options.discernmentTroubles,
+          },
+        })
+      }
+
+      default: {
+        handleNotAllowedMethods(req, res)
+      }
+    }
+  } catch (error) {
+    handleErrors(error, res)
+  }
+}
+
+const cors = Cors({
+  allowMethods: ["GET"],
+})
+
+export default cors(handler)

--- a/src/pages/api/nomenclatures.ts
+++ b/src/pages/api/nomenclatures.ts
@@ -16,7 +16,6 @@ function flatten(obj) {
 
 const handler = async (req, res) => {
   res.setHeader("Content-Type", "application/json")
-  res.setHeader("Cache-Control", "public, max-age=60, must-revalidate")
 
   try {
     switch (req.method) {

--- a/src/services/declarations/index.ts
+++ b/src/services/declarations/index.ts
@@ -7,9 +7,11 @@ import {
   schemaEts,
   schemaLiberal,
 } from "@/models/declarations"
+import { EditorModel } from "@/models/editor"
 
 export const create = async (
   declaration: DeclarationModel,
+  editor: EditorModel,
 ): Promise<string | undefined> => {
   // console.log("declaration dans API", declaration)
 
@@ -19,6 +21,7 @@ export const create = async (
       break
     }
     case DeclarationType.Ets: {
+      declaration.editorId = editor.id
       await schemaEts.parseAsync(declaration)
       break
     }

--- a/src/services/editors/index.ts
+++ b/src/services/editors/index.ts
@@ -1,0 +1,17 @@
+import { EditorModel } from "@/models/editor"
+import prisma from "@/prisma/db"
+
+export async function getEditorFromToken(
+  token: string,
+): Promise<EditorModel | null> {
+  const existingToken = await prisma.token.findUnique({
+    where: {
+      id: token,
+    },
+    include: {
+      editor: true,
+    },
+  })
+
+  return existingToken?.editor || null
+}

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -510,7 +510,7 @@ export const authorTypes = [...baseVictimsAuthors, "Inconnu"].sort((a, b) =>
 
 export const juridicStatus = ["Public", "Privé"]
 
-const healthTypes = ["Étudiant en santé", "Professionnel de santé"]
+export const healthTypes = ["Étudiant en santé", "Professionnel de santé"]
 
 export const pursuits = ["Non", "Main courante", "Plainte"]
 

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -12,13 +12,13 @@ export const DEFAULT_PAGE_SIZE = 50
  * Compute all useful variables for pagination.
  */
 export async function buildMetaPagination({
+  totalCount,
   pageIndex,
   pageSize,
-  totalCount,
 }: {
-  pageIndex: number
-  pageSize: number
   totalCount: number
+  pageIndex?: number
+  pageSize?: number
 }): Promise<ReturnType> {
   pageIndex = Number(pageIndex) || 0
   pageSize = Number(pageSize) || DEFAULT_PAGE_SIZE


### PR DESCRIPTION
La table editors liste les éditeurs qui peuvent accéder à l'API de déclaration des actes.
La table tokens, rassemble les tokens valides, attribués aux éditeurs et qui doit être envoyé dans le champ `Authorization: Bearer`.

Une API des nomenclatures est ajoutée : elle permet aux éditeurs de savoir les valeurs acceptés par tous les champs de l'API de déclaration.

